### PR TITLE
Change bosh director

### DIFF
--- a/ci/jobs/compilation/scripts/create-release.sh
+++ b/ci/jobs/compilation/scripts/create-release.sh
@@ -53,7 +53,7 @@ bosh -e ${ALIAS} create-release --force
 bosh -e ${ALIAS} upload-release
 
 bosh -e ${ALIAS} -d ${DEPLOYMENT_NAME} -n deploy \
-    manifest.yml -v deployment=${DEPLOYMENT_NAME} -v release=${BOSH_RELEASE} \
+    ci/manifests/compilation.yml -v deployment=${DEPLOYMENT_NAME} -v release=${BOSH_RELEASE} \
     -v instance_group=${INSTANCE_GROUP} -v network=${NETWORK} \
     -v version=$(grep "^mongodb" ${ROOT_FOLDER}/uploaded/keyval.properties|cut -d"=" -f2)
 popd

--- a/ci/jobs/compilation/scripts/create-release.sh
+++ b/ci/jobs/compilation/scripts/create-release.sh
@@ -13,12 +13,14 @@ create_fake_files()
         mkdir -p dev_releases/${BOSH_RELEASE}
     fi
 
-    for release in $(bosh -e ${ALIAS} releases -d ${DEPLOYMENT_NAME} --column="Version"|tr -d "*")
+    for release in $(bosh -e ${ALIAS} releases | grep ${BOSH_RELEASE} \
+                    | sed -e 's/[^[:space:]]*[[:space:]]*\([^[:space:]]*\).*/\1/' | tr -d "*")
     do
 
         # get the hash of the release
-        commit_hash=$(bosh -e ${ALIAS} releases -d ${DEPLOYMENT_NAME} --column="Version" --column="commit hash" \
-                    |tr -d "*" |grep -w "^${release}"|tr -s "\t" " "|cut -d" " -f2|tr -d [:space:]|tr -d "+")
+        commit_hash=$(bosh -e ${ALIAS} releases --column="Version" --column="commit hash" \
+                    | tr -d "*" | grep -w "^${release}" | tr -s "\t" " "|cut -d" " -f2 \
+                    | tr -d [:space:] | tr -d "+")
 
         if [ ! -f dev_releases/${BOSH_RELEASE}/index.yml ]
         then

--- a/ci/jobs/compilation/scripts/create-release.sh
+++ b/ci/jobs/compilation/scripts/create-release.sh
@@ -54,6 +54,6 @@ bosh -e ${ALIAS} upload-release
 
 bosh -e ${ALIAS} -d ${DEPLOYMENT_NAME} -n deploy \
     ci/manifests/compilation.yml -v deployment=${DEPLOYMENT_NAME} -v release=${BOSH_RELEASE} \
-    -v instance_group=${INSTANCE_GROUP} -v network=${NETWORK} \
+    -v instance_group=${INSTANCE_GROUP} -v network=${NETWORK} -v director_uuid=${UUID} \
     -v version=$(grep "^mongodb" ${ROOT_FOLDER}/uploaded/keyval.properties|cut -d"=" -f2)
 popd

--- a/ci/manifests/compilation.yml
+++ b/ci/manifests/compilation.yml
@@ -1,5 +1,5 @@
 name: ((deployment))
-director_uuid: 8dd35958-abc4-46fc-9c96-f91c791bfeae
+director_uuid: ((director_uuid))
 
 releases:
   - name: ((release))
@@ -19,7 +19,7 @@ stemcells:
 
 instance_groups:
 - name: ((instance_group))
-  release: mongodb-compiler
+  release: ((release))
   lifecycle: errand
   azs: [z1]
   instances: 1

--- a/ci/mongodb-compilation.yml
+++ b/ci/mongodb-compilation.yml
@@ -143,12 +143,13 @@ jobs:
     - task: create-release
       file: mongodb-compilation-bosh-release/ci/jobs/compilation/tasks/create-release.yml
       params:
-        ALIAS: ((bosh-server.alias)) 
+        ALIAS: ((bosh-server.alias))
+        UUID: ((bosh-server.uuid))
         BOSH_RELEASE: ((bosh-deployment.release))
         DEPLOYMENT_NAME: ((bosh-deployment.name))
         INSTANCE_GROUP: ((bosh-deployment.instance-group))
         NETWORK: ((bosh-deployment.network))
-        
+
     - task: make-archive
       file: mongodb-compilation-bosh-release/ci/jobs/compilation/tasks/make-archive.yml
       params:


### PR DESCRIPTION
Use only one bosh-director for deployment and ci to allow future tests with shield backup tool and prometheus toolkit.